### PR TITLE
Project structure

### DIFF
--- a/src/modules/cobwebGrid/components/what_goes_here.txt
+++ b/src/modules/cobwebGrid/components/what_goes_here.txt
@@ -1,0 +1,1 @@
+Any React components that will be needed for the cobweb grid module

--- a/src/modules/cobwebGrid/processing/ai/what_goes_here.txt
+++ b/src/modules/cobwebGrid/processing/ai/what_goes_here.txt
@@ -1,0 +1,1 @@
+Everything from org/cobweb/cobweb2/impl/ai

--- a/src/modules/cobwebGrid/processing/what_goes_here.txt
+++ b/src/modules/cobwebGrid/processing/what_goes_here.txt
@@ -1,0 +1,1 @@
+All loose files (not in subfolders) in org/cobweb/cobweb2/impl

--- a/src/modules/cobwebGrid/views/what_goes_here.txt
+++ b/src/modules/cobwebGrid/views/what_goes_here.txt
@@ -1,0 +1,1 @@
+The grid view itself (putting the components together) as a React component

--- a/src/modules/io/what_goes_here.txt
+++ b/src/modules/io/what_goes_here.txt
@@ -1,0 +1,5 @@
+Similar idea to modules/overlays and modules/simulationSettings in this project, but for IO features (such as
+exporting the simulation to xml, exporting data to css spreadsheets, etc.)
+
+Useful stuff for this context will be in org/cobweb/io and org/cobweb/cobweb2/io, but there will have to be a lot
+built from the ground-up

--- a/src/modules/overlays/aiGraph/components/what_goes_here.txt
+++ b/src/modules/overlays/aiGraph/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/aiGraph/processing/what_goes_here.txt
+++ b/src/modules/overlays/aiGraph/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/aiGraph/views/what_goes_here.txt
+++ b/src/modules/overlays/aiGraph/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/discretizedGravity/components/what_goes_here.txt
+++ b/src/modules/overlays/discretizedGravity/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/discretizedGravity/processing/what_goes_here.txt
+++ b/src/modules/overlays/discretizedGravity/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/discretizedGravity/views/what_goes_here.txt
+++ b/src/modules/overlays/discretizedGravity/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/energy/components/what_goes_here.txt
+++ b/src/modules/overlays/energy/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/energy/processing/what_goes_here.txt
+++ b/src/modules/overlays/energy/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/energy/views/what_goes_here.txt
+++ b/src/modules/overlays/energy/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/geneticAlgorithmChart/components/what_goes_here.txt
+++ b/src/modules/overlays/geneticAlgorithmChart/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/geneticAlgorithmChart/processing/what_goes_here.txt
+++ b/src/modules/overlays/geneticAlgorithmChart/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/geneticAlgorithmChart/views/what_goes_here.txt
+++ b/src/modules/overlays/geneticAlgorithmChart/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/productionValue/components/what_goes_here.txt
+++ b/src/modules/overlays/productionValue/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/productionValue/processing/what_goes_here.txt
+++ b/src/modules/overlays/productionValue/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/productionValue/views/what_goes_here.txt
+++ b/src/modules/overlays/productionValue/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/regionalStats/components/what_goes_here.txt
+++ b/src/modules/overlays/regionalStats/components/what_goes_here.txt
@@ -1,0 +1,3 @@
+Any react components that will be needed to make this overlay or the popup window (split those up into seperate
+subfolders of this folder if needed). Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/overlays/regionalStats/processing/what_goes_here.txt
+++ b/src/modules/overlays/regionalStats/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this overlay's folder located in org/cobweb/cobweb2/ui/swing that has to do with processing what is
+shown in the overlay and popup window (feel free to seperate this into two subfolders, one for the overlay and one
+for the popup window)

--- a/src/modules/overlays/regionalStats/views/what_goes_here.txt
+++ b/src/modules/overlays/regionalStats/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+Two views, one for the overlay and one for the popup info window, both of them implementing the interfaces for them
+from shared/views/overlays. Inspiration/framework for this be found in this overlay's folder located in
+org/cobweb/cobweb2/ui/swing

--- a/src/modules/simulationSettings/abiotic/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/abiotic/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/abiotic/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/abiotic/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/abiotic/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/abiotic/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/agentStats/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/agentStats/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/agentStats/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/agentStats/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/agentStats/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/agentStats/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/ai/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/ai/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/ai/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/ai/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/ai/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/ai/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/broadcast/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/broadcast/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/broadcast/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/broadcast/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/broadcast/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/broadcast/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/disease/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/disease/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/disease/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/disease/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/disease/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/disease/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/environment/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/environment/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/environment/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/environment/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/environment/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/environment/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/foodWeb/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/foodWeb/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/foodWeb/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/foodWeb/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/foodWeb/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/foodWeb/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/fusion/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/fusion/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/fusion/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/fusion/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/fusion/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/fusion/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/genetics/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/genetics/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/genetics/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/genetics/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/genetics/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/genetics/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/gravity/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/gravity/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/gravity/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/gravity/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/gravity/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/gravity/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/learning/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/learning/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/learning/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/learning/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/learning/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/learning/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/personalities/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/personalities/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/personalities/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/personalities/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/personalities/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/personalities/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/prisonersDilemma/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/prisonersDilemma/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/prisonersDilemma/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/prisonersDilemma/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/prisonersDilemma/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/prisonersDilemma/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/production/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/production/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/production/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/production/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/production/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/production/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/resources/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/resources/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/resources/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/resources/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/resources/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/resources/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/swarm/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/swarm/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/swarm/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/swarm/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/swarm/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/swarm/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/toxin/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/toxin/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/toxin/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/toxin/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/toxin/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/toxin/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/vision/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/vision/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/vision/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/vision/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/vision/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/vision/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/waste/components/what_goes_here.txt
+++ b/src/modules/simulationSettings/waste/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any react components that will be needed to make this simulation settings panel. To get a specific view of what will
+be needed, find this settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/modules/simulationSettings/waste/processing/what_goes_here.txt
+++ b/src/modules/simulationSettings/waste/processing/what_goes_here.txt
@@ -1,0 +1,3 @@
+Everything in this simulation settings' folder in org/cobweb/cobweb2/plugins (the specific subfolders, i.e. abiotic,
+not just any files lying around in this folder or a subfolder. MAKE SURE THE NAME/IDEA OF THIS FOLDER MATCHES THE
+SUBFOLDER OF org/cobweb/cobweb2/plugins YOU'RE TAKING FROM)

--- a/src/modules/simulationSettings/waste/views/what_goes_here.txt
+++ b/src/modules/simulationSettings/waste/views/what_goes_here.txt
@@ -1,0 +1,3 @@
+One view that will house all of the react components for this settings panel. Should implement the interface for a
+settings panel in shared/views/simulationSettings. To get a specific view of what will be needed, find this
+settings panel's file in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/routes/what_goes_here.txt
+++ b/src/routes/what_goes_here.txt
@@ -1,0 +1,1 @@
+The structure for the routes of the website (home, auth, settings, etc.)

--- a/src/shared/components/overlays/what_goes_here.txt
+++ b/src/shared/components/overlays/what_goes_here.txt
@@ -1,0 +1,2 @@
+Everything from org/cobweb/cobweb2/ui/swing that can be a component or an interface for a component (things that
+weren't added to shared/processing/overlays)

--- a/src/shared/components/simulationSettings/what_goes_here.txt
+++ b/src/shared/components/simulationSettings/what_goes_here.txt
@@ -1,0 +1,1 @@
+Common components that would be useful when making the simulation settings panels

--- a/src/shared/components/what_goes_here.txt
+++ b/src/shared/components/what_goes_here.txt
@@ -1,0 +1,2 @@
+Any React components that will be shared among many modules. Some things from org/cobweb/swingutil may be useful to
+recreate here (use discretion)

--- a/src/shared/processing/overlays/accessors/what_goes_here.txt
+++ b/src/shared/processing/overlays/accessors/what_goes_here.txt
@@ -1,0 +1,1 @@
+Everything in from org/cobweb/cobweb2/ui/config

--- a/src/shared/processing/overlays/what_goes_here.txt
+++ b/src/shared/processing/overlays/what_goes_here.txt
@@ -1,0 +1,2 @@
+All loose files (not in subfolders) in org/cobweb/cobweb2/ui, and things in org/cobweb/cobweb2/ui/swing that aren't
+components or interfaces for components (those should go in shared/components/overlays)

--- a/src/shared/processing/simulationSettings/what_goes_here.txt
+++ b/src/shared/processing/simulationSettings/what_goes_here.txt
@@ -1,0 +1,1 @@
+All loose files (not in subfolders) in org/cobweb/cobweb2/plugins

--- a/src/shared/processing/what_goes_here.txt
+++ b/src/shared/processing/what_goes_here.txt
@@ -1,0 +1,1 @@
+Everything in org/cobweb/cobweb2/core, also the simulation and simulationConfig files in org/cobweb/cobweb2

--- a/src/shared/utils/what_goes_here.txt
+++ b/src/shared/utils/what_goes_here.txt
@@ -1,0 +1,2 @@
+Functions, classes, or interfaces that will be useful for many applications across the project (e.g. getting
+environment variables). Some things from org/cobweb/util may be useful to recreate here (use discretion)

--- a/src/shared/views/overlays/what_goes_here.txt
+++ b/src/shared/views/overlays/what_goes_here.txt
@@ -1,0 +1,2 @@
+React component views that will be shared among different overlays. More importantly, the interfaces for overlays
+and popup info windows. Inspiration/framework for this can be found in the org/cobweb/cobweb2/ui/swing folder

--- a/src/shared/views/simulationSettings/what_goes_here.txt
+++ b/src/shared/views/simulationSettings/what_goes_here.txt
@@ -1,0 +1,3 @@
+React component views that will be shared among simulation settings. More importantly, the interfaces for
+simulation settings panels. Inspiration/framework for this can be found in a few of the more general files (namely
+the interfaces) in the org/cobweb/cobweb2/ui/swing/config folder

--- a/src/shared/views/what_goes_here.txt
+++ b/src/shared/views/what_goes_here.txt
@@ -1,0 +1,1 @@
+The React component views that will be shared among many modules (e.g. the navbar)


### PR DESCRIPTION
Outlines the full project structure with detailed "what_goes_here.txt" files giving instructions on what to put in each folder. THESE FILES MAY NOT ALWAYS BE 100% COMPREHENSIVE, BUT THEY WILL GIVE A VERY GOOD IDEA ON WHAT GOES WHERE.

General idea of structure: 3 main folders in src: modules, routes, and shared.
- modules will have segmented areas of functionality (one for the main cobweb grid, and a few more general categories that will carry their own modules: io, overlays, and simulationSettings). Each module folder will have 3 subfolders: components (which will carry the React components that will be needed for this module), views (which will put those react components together for the full view that will be needed for that module), and processing (which handles all of the logic for the module)
- shared will have 4 main subfolders: components, views, processing, and utils (which will have their own subfolders, sometimes pertaining to a certain type of use case such as overlays or simulationSettings)
- routes will determine the frontend URL routes of the web app, which will be controlled from src/App.tsx